### PR TITLE
chore(build): Remove prisma migrate from build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "npm run db:migrate:deploy && npx prisma generate && npx dotenv-cli -e .env.local -- bash -c '(node scripts/build-bibliography.js && node scripts/validate-citations.js && node scripts/build-citation-map.js) & (node scripts/build-graph-billets.cjs && node scripts/render-graph-svg.cjs) & (node scripts/build-search-index.js); wait' && next build",
+    "build": "npx prisma generate && npx dotenv-cli -e .env.local -- bash -c '(node scripts/build-bibliography.js && node scripts/validate-citations.js && node scripts/build-citation-map.js) & (node scripts/build-graph-billets.cjs && node scripts/render-graph-svg.cjs) & (node scripts/build-search-index.js); wait' && next build",
     "build:analyze": "ANALYZE=true npm run build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## Objectif
Éliminer les erreurs P1001 (connexion DB) durant le build Vercel en retirant `npm run db:migrate:deploy` du pipeline.

## Changements
- ✅ Supprime `npm run db:migrate:deploy &&` du script `build` dans package.json
- ✅ Conserve `npx prisma generate` et le reste du pipeline 
- ✅ Les migrations doivent être appliquées manuellement en production

## Contexte
- La table PressClip a été créée manuellement en production via SQL
- Les migrations en build créent des erreurs de connectivité réseau
- Séparation build/deploy est une bonne pratique

## Tests
- ✅ Build local fonctionne sans erreur
- ✅ TypeScript check passe
- ✅ Pipeline parallélisé (bibliographie, graph, recherche) preserved

🤖 Generated with [Claude Code](https://claude.ai/code)